### PR TITLE
added basic Python 3 support. TODO: kill all the execs

### DIFF
--- a/platon/transit_depth_calculator.py
+++ b/platon/transit_depth_calculator.py
@@ -552,9 +552,9 @@ class TransitDepthCalculator:
             = self._get_binned_corrected_depths(transit_depths, T_star, T_spot, spot_cov_frac)
         if InstNum:
             for I in range(InstNum): #CHIMA. To add offsets
-                AddOff = "binned_depths[np.logical_and(binned_wavelengths > Offset_kwargs['Offset"+str(I+1)+"_Wavs'][0],"
-                AddOff += "binned_wavelengths < Offset_kwargs['Offset"+str(I+1)+"_Wavs'][1])] += Offset_kwargs['Offset"+str(I+1)+"']"
-                exec(AddOff) 
+                cond1 = binned_wavelengths > Offset_kwargs[f"Offset{I+1}_Wavs"][0]
+                cond2 = binned_wavelengths < Offset_kwargs[f"Offset{I+1}_Wavs"][1]
+                binned_depths[np.logical_and(cond1, cond2)] += Offset_kwargs[f"Offset{I+1}"]
         if full_output:
             output_dict = {"absorption_coeff_atm": absorption_coeff_atm,
                            "tau_los": tau_los,

--- a/retrieval_input.py
+++ b/retrieval_input.py
@@ -38,7 +38,7 @@ spot_cov_fracBnds = None #[0,0.6]
 #Offsets per each insturment you have. CAN take arbitrary number of offsets. Include offset parameters even,
 #even if specific insturment doesn't need offset. It needs to be included for formating purposes. 
 #Just set all terms to 0 if no offsets are needed. Have offsets orded in same order of .dat file
-NumInst = None #3 #Should reflect number of offsets. None if absolutely no offset needed
+NumInst = 3 #Should reflect number of offsets. None if absolutely no offset needed
 Offset1 = 0.0001  #For IMACS/Magellan, initial offset guess
 Offset1_Rng = 0.5 # fraction of MeanDepth for prior on offset
 Offset1_Wavs = [3.5e-7, 1e-6] #Wavlength range, in meters, which insturment observes

--- a/retriever_multinest.py
+++ b/retriever_multinest.py
@@ -7,7 +7,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import scipy.interpolate
 import emcee
-import corner
+# import corner
 import pickle
 import retrieval_input as RI
 import datetime
@@ -59,7 +59,7 @@ if NumInst:
 # First, extract data:
 data_fname = 'Dats/'+RI.dataset+'.dat'
 print("Using: "+RI.dataset+'.dat')
-data = np.genfromtxt(data_fname,dtype=None)
+data = np.genfromtxt(data_fname, dtype=None, encoding=None)
 
 # Save it into our data dictionary:
 data_dictionary = {}
@@ -90,7 +90,7 @@ bins_up =  np.array([])
 bins_dwn = np.array([])
 depths = np.array([])
 errors = np.array([])
-Inst = data_dictionary.keys()
+Inst = list(data_dictionary.keys())
 InstWavRng = []
 for i in range(len(Inst)):
     bins_up = np.append(bins_up, data_dictionary[Inst[i]]['wup']*1e-10) # to convert from angstrom to meters


### PR DESCRIPTION
It turns out that the way `exec` is interpreted changed from Python 2 -> 3. In 2, ALL local variables within the function scope were passed up the chain in the `exec` call. This is bad for security and performance, so this functionality was snipped in 3. To get around this, I converted the function arguments that were originally created with `exec` into a dictionary.  I also made a couple other Python 3 specific changes (e.g. f-strings, generator -> list, and explicit encoding) shown below.

TL;DR: `exec` is non-optimized and not secure. Avoid if possible in the future.

More info here:
https://stackoverflow.com/questions/1933451/why-should-exec-and-eval-be-avoided
https://stackoverflow.com/a/15087355
